### PR TITLE
Fix asset creation (2020.2)

### DIFF
--- a/examples/basic-usage/Assets/LineobjImporter.cs
+++ b/examples/basic-usage/Assets/LineobjImporter.cs
@@ -51,6 +51,7 @@ public class LineobjImporter : ScriptedImporter
         MeshRenderer renderer = mainAsset.AddComponent<MeshRenderer>();
         renderer.materials = materials;
 
+        ctx.AddObjectToAsset(assetName, mainAsset);
         ctx.SetMainObject(mainAsset);
     }
 


### PR DESCRIPTION
Adds the main asset GameObject to the AssetImportContext before calling SetMainObject().
The change silences all editor error messages on import and properly creates a prefab asset in Unity 2020.2.

Thanks for creating this—really coming in handy!
